### PR TITLE
산업 내 기업 순위 조회

### DIFF
--- a/companies/models.py
+++ b/companies/models.py
@@ -13,3 +13,17 @@ class Company(models.Model):
 
     class Meta:
         db_table = 'company'
+        
+class StockPrice(models.Model):
+    company = models.ForeignKey(Company, on_delete=models.CASCADE, related_name='stock_prices', db_column='company_ticker_symbol') # 기업 티커 심볼
+    time = models.BigIntegerField(help_text="Unix Timestamp") # 시간 (타임스탬프)
+    open_price = models.FloatField() # 시가
+    close_price = models.FloatField() # 종가
+    high_price = models.FloatField() # 고가
+    low_price = models.FloatField() # 저가
+    volume = models.BigIntegerField() # 거래량
+    trans_amount = models.BigIntegerField() # 거래대금
+
+    class Meta:
+        db_table = 'stock_price'
+        unique_together = ('company', 'time')

--- a/companies/models.py
+++ b/companies/models.py
@@ -6,7 +6,7 @@ class Company(models.Model):
     industry = models.ForeignKey('industries.Industry', on_delete=models.CASCADE, related_name='companies', db_column='industry_id') # 산업 아이디
     company_name = models.CharField(max_length=255) # 기업 이름
     description = models.TextField() # 설명
-    rank_in_industry = models.IntegerField() # 명세서의 rankInIndustry 산업 내 기업 순위
+    market_amount = models.BigIntegerField(default=0) # 시가총액
     created_at = models.DateTimeField(auto_now_add=True) # 생성 일시
     updated_at = models.DateTimeField(auto_now=True) # 수정 일시
     is_deleted = models.BooleanField(default=False) # 삭제 여부
@@ -14,16 +14,3 @@ class Company(models.Model):
     class Meta:
         db_table = 'company'
         
-class StockPrice(models.Model):
-    company = models.ForeignKey(Company, on_delete=models.CASCADE, related_name='stock_prices', db_column='company_ticker_symbol') # 기업 티커 심볼
-    time = models.BigIntegerField(help_text="Unix Timestamp") # 시간 (타임스탬프)
-    open_price = models.FloatField() # 시가
-    close_price = models.FloatField() # 종가
-    high_price = models.FloatField() # 고가
-    low_price = models.FloatField() # 저가
-    volume = models.BigIntegerField() # 거래량
-    trans_amount = models.BigIntegerField() # 거래대금
-
-    class Meta:
-        db_table = 'stock_price'
-        unique_together = ('company', 'time')

--- a/companies/serializers.py
+++ b/companies/serializers.py
@@ -11,4 +11,4 @@ class CompanySerializer(serializers.ModelSerializer):
         
  
     def get_rank(self, obj):
-        return self.context.get('rank_dict', {}).get(obj.ticker_symbol, 0)
+        return self.context.get('rank_dict', {}).get(obj.ticker_symbol, None)

--- a/companies/serializers.py
+++ b/companies/serializers.py
@@ -4,6 +4,11 @@ from rest_framework import serializers
 from .models import Company
 
 class CompanySerializer(serializers.ModelSerializer):
+    rank = serializers.SerializerMethodField()
     class Meta:
         model = Company
-        fields = ['ticker_symbol', 'company_name', 'description', 'rank_in_industry']
+        fields = ['ticker_symbol', 'company_name', 'description', 'rank']
+        
+ 
+    def get_rank(self, obj):
+        return self.context.get('rank_dict', {}).get(obj.ticker_symbol, 0)

--- a/config/urls.py
+++ b/config/urls.py
@@ -22,7 +22,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/core/', include('core.urls')),      # 기존 경로
     path('api/companies/', include('companies.urls')), # 기존 경로
-
+    # 산업
+    path('api/industries/', include('industries.urls')),
     # 문서 데이터(Schema) 생성 엔진
     path('api/schema/', SpectacularAPIView.as_view(), name='schema'),
     # Swagger UI (위에서 만든 schema를 시각화)

--- a/industries/urls.py
+++ b/industries/urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from .views import IndustryCompanyRankView # 이전 답변에서 작성한 View
+
+urlpatterns = [
+    # config에서 'api/industries/'로 들어왔으므로, 여기서는 그 뒷부분만 정의합니다.
+    path('<int:industry_id>/companies', IndustryCompanyRankView.as_view(), name='industry_company_rank'),
+]

--- a/industries/views.py
+++ b/industries/views.py
@@ -1,3 +1,70 @@
-from django.shortcuts import render
+# industries/views.py 혹은 별도 위치
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status, serializers
+from drf_spectacular.utils import extend_schema, OpenApiResponse, inline_serializer
+from companies.models import Company
+from .models import Industry
+from companies.serializers import CompanySerializer
 
-# Create your views here.
+class IndustryCompanyRankView(APIView):
+    @extend_schema(
+        summary="산업 내 기업 순위 조회",
+        description="특정 산업 ID를 입력받아 해당 산업에 속한 기업들의 순위(시가총액 순)를 조회합니다.",
+        responses={
+            200: inline_serializer(
+                name='IndustryRankResponse',
+                fields={
+                    "status": serializers.IntegerField(),
+                    "message": serializers.CharField(default="해당 산업 내 기업 순위 조회를 성공하였습니다."),
+                    "data": CompanySerializer(many=True) # 리스트 형태임을 명시
+                }
+            ),
+            404: OpenApiResponse(
+                description="항목을 찾을 수 없음",
+                response=inline_serializer(
+                    name='NotFoundResponse',
+                    fields={
+                        "status": serializers.IntegerField(default=404),
+                        "code": serializers.CharField(default="NOT_FOUND"),
+                        "message": serializers.CharField(default="항목을 찾을 수 없습니다.")
+                    }
+                )
+            )
+        },
+        tags=["Industry"]
+    )
+    def get(self, request, industry_id):
+        # 1. 산업 존재 여부 확인 (없으면 404 에러 코드 형식에 맞춰 반환)
+        try:
+            industry = Industry.objects.get(pk=industry_id)
+        except Industry.DoesNotExist:
+            return Response({
+                "status": 404,
+                "code": "NOT_FOUND",
+                "message": "항목을 찾을 수 없습니다."
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        # 2. 해당 산업의 기업들을 marketAmount 내림차순으로 조회
+        companies = Company.objects.filter(industry=industry).order_by('rank_in_industry')
+
+        if not companies.exists():
+            return Response({
+                "status": 404,
+                "code": "NOT_FOUND",
+                "message": "해당 산업에 등록된 기업이 없습니다."
+            }, status=status.HTTP_404_NOT_FOUND)
+
+        # 3. 순위 계산 (리스트 인덱스 활용)
+        rank_dict = {company.ticker_symbol: i + 1 for i, company in enumerate(companies)}
+
+        # 4. 시리얼라이징
+        serializer = CompanySerializer(companies, many=True, context={'rank_dict': rank_dict})
+
+        # 5. 최종 응답 형식 맞추기
+        return Response({
+            "status": 200,
+            "message": "해당 산업 내 기업 순위 조회를 성공하였습니다.",
+            "data": serializer.data
+        }, status=status.HTTP_200_OK)
+

--- a/industries/views.py
+++ b/industries/views.py
@@ -10,7 +10,7 @@ from companies.serializers import CompanySerializer
 class IndustryCompanyRankView(APIView):
     @extend_schema(
         summary="산업 내 기업 순위 조회",
-        description="특정 산업 ID를 입력받아 해당 산업에 속한 기업들의 순위(시가총액 순)를 조회합니다.",
+        description="특정 산업 ID를 입력받아 해당 산업에 속한 기업들의 순위를 조회합니다.",
         responses={
             200: inline_serializer(
                 name='IndustryRankResponse',
@@ -45,7 +45,7 @@ class IndustryCompanyRankView(APIView):
                 "message": "항목을 찾을 수 없습니다."
             }, status=status.HTTP_404_NOT_FOUND)
 
-        # 2. 해당 산업의 기업들을 marketAmount 내림차순으로 조회
+        # 2. 해당 산업의 기업들을 오름차순으로 산업 내 기업 순위 조회
         companies = Company.objects.filter(industry=industry).order_by('rank_in_industry')
 
         if not companies.exists():

--- a/industries/views.py
+++ b/industries/views.py
@@ -45,8 +45,8 @@ class IndustryCompanyRankView(APIView):
                 "message": "항목을 찾을 수 없습니다."
             }, status=status.HTTP_404_NOT_FOUND)
 
-        # 2. 해당 산업의 기업들을 오름차순으로 산업 내 기업 순위 조회
-        companies = Company.objects.filter(industry=industry).order_by('rank_in_industry')
+        # 2. 해당 산업의 기업들을 시가총액 내림차순으로 조회
+        companies = Company.objects.filter(industry=industry, is_deleted=False).order_by('-market_amount')
 
         if not companies.exists():
             return Response({
@@ -56,7 +56,14 @@ class IndustryCompanyRankView(APIView):
             }, status=status.HTTP_404_NOT_FOUND)
 
         # 3. 순위 계산 (리스트 인덱스 활용)
-        rank_dict = {company.ticker_symbol: i + 1 for i, company in enumerate(companies)}
+        rank_dict = {}
+        current_rank = 1
+
+        for i, company in enumerate(companies):
+            # 이전 기업과 시가총액이 다를 때만 현재 순위를 갱신
+            if i > 0 and company.market_amount < companies[i-1].market_amount:
+                current_rank = i + 1
+            rank_dict[company.ticker_symbol] = current_rank
 
         # 4. 시리얼라이징
         serializer = CompanySerializer(companies, many=True, context={'rank_dict': rank_dict})


### PR DESCRIPTION
<!-- 제목 예시: [feat] 관리자 페이지 구현 -->
<!-- 작성하지 않은 항목은 모두 지워주세요 -->
 
## 🔎개요 

특정 산업군을 선택했을 때 해당 산업에 속한 기업들의 순위 정보를 조회할 수 있는 API를 구현했습니다. 
 
<br/>
 
## 📝작업 내용

1. 산업별 기업 필터링 및 정렬 로직 구현

IndustryCompanyRankView를 통해 입력받은 식별자(ID 또는 이름)에 해당하는 산업을 검색합니다.

해당 산업에 속한 기업들을 rank_in_industry 기준으로 정렬하여 가져오도록 구현했습니다.

2. 동적 순위(Rank) 계산 로직 추가

DB에 저장된 고정값이 아닌, 조회 시점의 리스트 인덱스를 바탕으로 1위부터 순차적인 순위를 부여하는 기능을 SerializerMethodField와 context를 통해 구현했습니다.

3. Swagger 문서화 (drf-spectacular)

@extend_schema와 inline_serializer를 사용하여 status, message, data 구조를 가진 커스텀 응답 형태를 Swagger UI에 명시했습니다.
 
 
<br/>
 
## 👀변경 사항

1. 시리얼라이저 확장: 기존 CompanySerializer에 순위 조회를 위한 rank 필드와 컨텍스트 기반 로직이 추가되었습니다. 다른 곳에서 해당 시리얼라이저를 호출할 때 rank_dict가 포함된 컨텍스트가 없으면 rank는 기본값 0으로 출력됩니다.

2. 에러 핸들링: 산업이 존재하지 않거나 해당 산업에 기업이 없을 경우 명세서 규격에 맞는 404 에러 객체를 반환합니다.
 
<br/>
 
## 📸UI 스크린샷

해당없음(백엔드 api 구현)
 
 
<br/>
 
## 📦패키지 설치

없음
 
 
<br/>
 
 
## #️⃣관련 이슈
feat/#8 (같은 models.py(companies, industries)를 사용함)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 업계별 회사 순위를 조회하는 신규 API 엔드포인트 제공(산업별 회사 목록 및 순위 반환).
  * 회사 조회 응답에 순위(rank) 필드가 포함되어 반환되도록 통합.
  * 기업 데이터 스키마 변경: 기존 순위 필드 제거, 시장규모(market_amount) 필드가 추가되어 시장규모 기준으로 정렬된 순위가 응답에 반영됩니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->