### PR TITLE
[feat] 전체 기업 뉴스 동기화 Celery Beat 스케줄 추가

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -286,6 +286,17 @@ CELERY_BEAT_SCHEDULE = {
             "max_articles_per_keyword": 10,
         },
     },
+    # 전체 기업 뉴스 동기화: 뉴스 크롤링 30분 후 실행 (OpenSearch 검색 → CompanyNews 매핑)
+    "sync-all-companies-news-every-3-hours": {
+        "task": "news.tasks.company_news.sync_all_companies_news_task",
+        "schedule": 3 * 60 * 60,  # 3시간 (초 단위)
+        "kwargs": {
+            "max_news": 20,
+            "days_back": 30,
+            "batch_size": 50,
+        },
+        "options": {"countdown": 30 * 60},  # 뉴스 크롤링 30분 후 실행
+    },
     "sync-industry-charts-daily": {
         # 오후 4시 10분에 실행
         "task": "industries.tasks.index_sync.sync_industry_charts_daily",

--- a/news/tasks/__init__.py
+++ b/news/tasks/__init__.py
@@ -25,6 +25,7 @@ from .company_news import (
     crawl_company_news_task,
     crawl_top_companies_news_task,
     crawl_single_company_news_sync,
+    sync_all_companies_news_task,
 )
 
 __all__ = [
@@ -49,4 +50,5 @@ __all__ = [
     "crawl_company_news_task",
     "crawl_top_companies_news_task",
     "crawl_single_company_news_sync",
+    "sync_all_companies_news_task",
 ]

--- a/news/tasks/company_news.py
+++ b/news/tasks/company_news.py
@@ -396,6 +396,87 @@ def sync_company_news_task(
         return {"success": 0, "error": str(e)}
 
 
+@shared_task(bind=True, max_retries=2)
+def sync_all_companies_news_task(
+    self, max_news: int = 20, days_back: int = 30, batch_size: int = 50
+) -> Dict[str, Any]:
+    """
+    전체 기업 뉴스 동기화 태스크 (Celery Beat 스케줄용)
+
+    DB에 있는 모든 기업에 대해 뉴스 동기화 작업을 비동기로 등록합니다.
+    각 기업별로 OpenSearch에서 관련 뉴스를 검색하여 CompanyNews에 매핑합니다.
+
+    Args:
+        max_news: 기업당 최대 뉴스 수 (기본값: 20)
+        days_back: 검색 기간 (일, 기본값: 30)
+        batch_size: 배치 크기 (기본값: 50)
+
+    Returns:
+        dict: 동기화 결과 통계
+    """
+    from companies.models import Company
+
+    logger.info("[SyncAllCompaniesNews] 전체 기업 뉴스 동기화 시작")
+
+    try:
+        # 활성 기업 목록 조회
+        companies = Company.objects.filter(is_deleted=False).values_list(
+            "stock_code", flat=True
+        )
+        company_list = list(companies)
+        total_count = len(company_list)
+
+        if total_count == 0:
+            logger.warning("[SyncAllCompaniesNews] 동기화할 기업이 없습니다.")
+            return {"total_companies": 0, "scheduled_tasks": 0}
+
+        logger.info(f"[SyncAllCompaniesNews] {total_count}개 기업 동기화 예정")
+
+        # 배치로 나눠서 태스크 등록
+        scheduled_count = 0
+        for i in range(0, total_count, batch_size):
+            batch = company_list[i : i + batch_size]
+            countdown_offset = (i // batch_size) * 10  # 배치별 10초 간격
+
+            for stock_code in batch:
+                try:
+                    sync_company_news_task.apply_async(
+                        args=[stock_code, max_news, days_back],
+                        countdown=countdown_offset,
+                    )
+                    scheduled_count += 1
+                except Exception as e:
+                    logger.error(
+                        f"[SyncAllCompaniesNews] 태스크 등록 실패: {stock_code} - {e}"
+                    )
+
+            logger.info(
+                f"[SyncAllCompaniesNews] 배치 {i // batch_size + 1} 완료: "
+                f"{len(batch)}개 기업 등록"
+            )
+
+        result = {
+            "total_companies": total_count,
+            "scheduled_tasks": scheduled_count,
+            "max_news": max_news,
+            "days_back": days_back,
+        }
+
+        logger.info(
+            f"[SyncAllCompaniesNews] 완료: {scheduled_count}/{total_count}개 태스크 등록"
+        )
+
+        return result
+
+    except Exception as e:
+        logger.error(f"[SyncAllCompaniesNews] 오류 발생: {e}")
+
+        if self.request.retries < self.max_retries:
+            raise self.retry(exc=e, countdown=60)
+
+        return {"error": str(e)}
+
+
 def _is_content_relevant_to_company(title: str, content: str, company) -> bool:
     """
     뉴스 제목과 본문에서 기업명이 실제로 언급되는지 확인합니다.


### PR DESCRIPTION
## 🔎 개요
전체 기업에 대해 뉴스 동기화를 수행하는 Celery Beat 스케줄 추가

## 📝 작업 내용
- `sync_all_companies_news_task` Celery 태스크 추가
- 3시간마다 실행 (기존 뉴스 크롤링 30분 후)
- OpenSearch에서 관련 뉴스 검색 → CompanyNews 테이블에 매핑

## 👀 변경 사항
- `news/tasks/company_news.py`: 전체 기업 동기화 태스크 추가
- `config/settings.py`: Celery Beat 스케줄 등록

## 📦 패키지 설치
없음

## #️⃣ 관련 이슈
#87

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 모든 회사 뉴스의 주기적 자동 동기화가 추가되어 3시간마다 실행됩니다.
  * 배치 처리와 단계적 예약으로 대규모 동기화가 효율적으로 수행됩니다.
  * 동기화 실패 시 자동 재시도로 안정성이 향상되었습니다.
  * 동기화 범위(가져올 기사 수, 조회 기간, 배치 크기)를 설정해 최신성 및 성능을 조절할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->