### PR TITLE
[feat] KIS WebSocket PINGPONG 메커니즘 구현

### DIFF
--- a/companies/services/company_cleanup.py
+++ b/companies/services/company_cleanup.py
@@ -33,7 +33,8 @@ class CompanyCleanupService:
 
         Returns:
             True: 유효한 지표가 하나라도 있음
-            False: per, pbr, roe, debt_ratio, dividend_yield 모두 0이거나 null
+            False: per, pbr, roe, debt_ratio, dividend_yield 모두 0이거나 null이고,
+                   기본 재무 데이터(매출액, 자산 등)도 없음
         """
         # 가장 최근 재무제표 조회
         latest_statement = (
@@ -46,7 +47,18 @@ class CompanyCleanupService:
             # 재무제표가 없으면 유효하지 않음
             return False
 
-        # 5가지 지표 중 하나라도 유효한 값이 있으면 True
+        # 1. 기본 재무 데이터가 있으면 유효한 기업 (안전장치)
+        primary_data = [
+            latest_statement.revenue,
+            latest_statement.total_assets,
+            latest_statement.net_income,
+            latest_statement.total_equity,
+        ]
+        for data in primary_data:
+            if not CompanyCleanupService.is_metric_empty(data):
+                return True
+
+        # 2. 5가지 지표 중 하나라도 유효한 값이 있으면 True
         metrics = [
             latest_statement.per,
             latest_statement.pbr,

--- a/companies/services/company_cleanup.py
+++ b/companies/services/company_cleanup.py
@@ -32,9 +32,8 @@ class CompanyCleanupService:
         기업의 가장 최근 재무제표에서 유효한 재무지표가 있는지 확인
 
         Returns:
-            True: 유효한 지표가 하나라도 있음
-            False: per, pbr, roe, debt_ratio, dividend_yield 모두 0이거나 null이고,
-                   기본 재무 데이터(매출액, 자산 등)도 없음
+            True: 5가지 지표 중 4개 이상 유효함 (삭제하면 안 됨)
+            False: 5가지 지표 중 2개 이상이 0이거나 null (삭제 대상)
         """
         # 가장 최근 재무제표 조회
         latest_statement = (
@@ -47,18 +46,7 @@ class CompanyCleanupService:
             # 재무제표가 없으면 유효하지 않음
             return False
 
-        # 1. 기본 재무 데이터가 있으면 유효한 기업 (안전장치)
-        primary_data = [
-            latest_statement.revenue,
-            latest_statement.total_assets,
-            latest_statement.net_income,
-            latest_statement.total_equity,
-        ]
-        for data in primary_data:
-            if not CompanyCleanupService.is_metric_empty(data):
-                return True
-
-        # 2. 5가지 지표 중 하나라도 유효한 값이 있으면 True
+        # 5가지 지표 확인
         metrics = [
             latest_statement.per,
             latest_statement.pbr,
@@ -67,11 +55,14 @@ class CompanyCleanupService:
             latest_statement.dividend_yield,
         ]
 
-        for metric in metrics:
-            if not CompanyCleanupService.is_metric_empty(metric):
-                return True
+        # 비어있는(0 또는 null) 지표 개수 계산
+        empty_count = sum(
+            1 for metric in metrics if CompanyCleanupService.is_metric_empty(metric)
+        )
 
-        return False
+        # 2개 이상 비어있으면 삭제 대상 (False 반환)
+        # 1개 이하만 비어있으면 유효한 기업 (True 반환)
+        return empty_count < 2
 
     @staticmethod
     def find_companies_without_valid_metrics() -> List[str]:

--- a/kis-publisher/main.py
+++ b/kis-publisher/main.py
@@ -37,9 +37,6 @@ BATCH_SIZE = int(os.getenv("KIS_BATCH_SIZE", "5"))
 PING_INTERVAL = int(os.getenv("KIS_PING_INTERVAL", "30"))  # 30초마다 PING
 PING_TIMEOUT = int(os.getenv("KIS_PING_TIMEOUT", "10"))  # PONG 응답 타임아웃
 
-# 종료 플래그
-shutdown_event = asyncio.Event()
-
 # RPC 설정
 RPC_QUEUE_NAME = "subscription.commands"
 
@@ -127,6 +124,8 @@ class HeartbeatManager:
         """
         PINGPONG 메시지 처리.
 
+        KIS 가이드라인: 동일한 페이로드를 응답해야 함.
+
         Returns:
             True: PINGPONG 메시지 처리됨
             False: PINGPONG 메시지 아님
@@ -135,18 +134,17 @@ class HeartbeatManager:
             return False
 
         try:
-            # PONG 응답 전송
-            pong_response = json.dumps({"type": "PONG"})
-            await self._websocket.send(pong_response)
+            # 원본 메시지를 그대로 에코 (KIS 가이드라인)
+            await self._websocket.send(message)
             self.record_activity()
-            print("[HEARTBEAT] PINGPONG received, PONG sent")
+            print(f"[HEARTBEAT] PINGPONG received, echoed back: {message[:50]}")
             return True
         except Exception as e:
             print(f"[HEARTBEAT] Error sending PONG: {e}")
             return True
 
     async def _heartbeat_loop(self):
-        """주기적 PING 전송 및 타임아웃 체크"""
+        """비활성 타임아웃 체크 (서버 PINGPONG에 응답하는 방식)"""
         while self._is_running:
             try:
                 await asyncio.sleep(self._ping_interval)
@@ -163,14 +161,7 @@ class HeartbeatManager:
                     print(f"[HEARTBEAT] Connection timeout ({elapsed:.1f}s since last activity)")
                     raise websockets.ConnectionClosed(None, None)
 
-                # PING 메시지 전송
-                try:
-                    ping_message = json.dumps({"type": "PING"})
-                    await self._websocket.send(ping_message)
-                    print(f"[HEARTBEAT] PING sent (last activity: {elapsed:.1f}s ago)")
-                except websockets.ConnectionClosed:
-                    print("[HEARTBEAT] Connection closed during PING")
-                    break
+                print(f"[HEARTBEAT] Connection alive (last activity: {elapsed:.1f}s ago)")
 
             except asyncio.CancelledError:
                 break
@@ -275,6 +266,9 @@ async def setup_rpc_consumer(rabbitmq_channel, subscription_handler: Subscriptio
 
 async def run_publisher():
     global SUBSCRIBE_SYMBOLS
+
+    # 종료 이벤트 (per-loop 생성)
+    shutdown_event = asyncio.Event()
 
     # DB에서 초기 종목 코드 가져오기
     max_db_retries = 3

--- a/kis-publisher/main.py
+++ b/kis-publisher/main.py
@@ -3,11 +3,16 @@ KIS WebSocket Publisher.
 
 KIS API에서 실시간 체결 데이터를 수신하여 RabbitMQ로 발행합니다.
 RPC 명령을 통해 동적 구독/해제를 지원합니다.
+
+KIS 가이드라인 준수:
+- 연결 시도 → 접속 확인 → 구독 정보 등록 → 정보 수신 → PINGPONG 응답 처리 → 구독 해제 → 접속 해제
+- 연결/종료 간격 최소 1초 이상
 """
 
 import asyncio
 import json
 import os
+import signal
 import websockets
 import aio_pika
 import aiohttp
@@ -27,6 +32,14 @@ MAX_SUBSCRIBE_SYMBOLS = int(
 SUBSCRIPTION_DELAY = float(os.getenv("KIS_SUBSCRIPTION_DELAY", "0.5"))
 BATCH_DELAY = float(os.getenv("KIS_BATCH_DELAY", "1.0"))
 BATCH_SIZE = int(os.getenv("KIS_BATCH_SIZE", "5"))
+
+# PINGPONG 설정
+PING_INTERVAL = int(os.getenv("KIS_PING_INTERVAL", "30"))  # 30초마다 PING
+PING_TIMEOUT = int(os.getenv("KIS_PING_TIMEOUT", "10"))  # PONG 응답 타임아웃
+CONNECTION_CONFIRM_TIMEOUT = int(os.getenv("KIS_CONNECTION_CONFIRM_TIMEOUT", "10"))  # 연결 확인 타임아웃
+
+# 종료 플래그
+shutdown_event = asyncio.Event()
 
 # RPC 설정
 RPC_QUEUE_NAME = "subscription.commands"
@@ -61,6 +74,133 @@ class KISParser:
         except (IndexError, ValueError) as e:
             print(f"Parsing error: {e}")
             return None
+
+    @staticmethod
+    def is_pingpong_message(message: str) -> bool:
+        """PINGPONG 메시지인지 확인"""
+        if not message:
+            return False
+        # KIS API PINGPONG 메시지 형식 확인
+        return "PINGPONG" in message.upper() or message.strip().upper() == "PING"
+
+    @staticmethod
+    def is_connection_confirm(message: str) -> bool:
+        """연결 확인 메시지인지 확인"""
+        if not message:
+            return False
+        try:
+            # JSON 형식 응답 확인
+            data = json.loads(message)
+            # 연결 성공 응답 확인 (tr_id가 있거나 성공 메시지)
+            if isinstance(data, dict):
+                header = data.get("header", {})
+                body = data.get("body", {})
+                # 연결 확인 또는 구독 성공 응답
+                if header.get("tr_id") or body.get("rt_cd") == "0":
+                    return True
+        except (json.JSONDecodeError, TypeError):
+            pass
+        # 문자열 형식 확인
+        msg_upper = message.upper()
+        return "CONNECTED" in msg_upper or "SUCCESS" in msg_upper
+
+
+class HeartbeatManager:
+    """
+    KIS WebSocket PINGPONG 관리.
+
+    KIS 가이드라인: 데이터가 없을 시 PINGPONG 응답 처리 필수
+    """
+
+    def __init__(self, websocket, ping_interval: int = 30, ping_timeout: int = 10):
+        self._websocket = websocket
+        self._ping_interval = ping_interval
+        self._ping_timeout = ping_timeout
+        self._last_pong_time = asyncio.get_event_loop().time()
+        self._heartbeat_task = None
+        self._is_running = False
+
+    async def start(self):
+        """하트비트 태스크 시작"""
+        if self._heartbeat_task and not self._heartbeat_task.done():
+            return
+
+        self._is_running = True
+        self._last_pong_time = asyncio.get_event_loop().time()
+        self._heartbeat_task = asyncio.create_task(self._heartbeat_loop())
+        print(f"[HEARTBEAT] Started (interval={self._ping_interval}s, timeout={self._ping_timeout}s)")
+
+    async def stop(self):
+        """하트비트 태스크 중지"""
+        self._is_running = False
+        if self._heartbeat_task:
+            self._heartbeat_task.cancel()
+            try:
+                await self._heartbeat_task
+            except asyncio.CancelledError:
+                pass
+        print("[HEARTBEAT] Stopped")
+
+    def record_activity(self):
+        """데이터 수신 시 호출 - 연결 활성 상태 기록"""
+        self._last_pong_time = asyncio.get_event_loop().time()
+
+    async def handle_pingpong(self, message: str) -> bool:
+        """
+        PINGPONG 메시지 처리.
+
+        Returns:
+            True: PINGPONG 메시지 처리됨
+            False: PINGPONG 메시지 아님
+        """
+        if not KISParser.is_pingpong_message(message):
+            return False
+
+        try:
+            # PONG 응답 전송
+            pong_response = json.dumps({"type": "PONG"})
+            await self._websocket.send(pong_response)
+            self.record_activity()
+            print("[HEARTBEAT] PINGPONG received, PONG sent")
+            return True
+        except Exception as e:
+            print(f"[HEARTBEAT] Error sending PONG: {e}")
+            return True
+
+    async def _heartbeat_loop(self):
+        """주기적 PING 전송 및 타임아웃 체크"""
+        while self._is_running:
+            try:
+                await asyncio.sleep(self._ping_interval)
+
+                if not self._is_running:
+                    break
+
+                # 마지막 활동 시간 체크
+                current_time = asyncio.get_event_loop().time()
+                elapsed = current_time - self._last_pong_time
+
+                if elapsed > self._ping_interval + self._ping_timeout:
+                    # 타임아웃 - 연결이 끊어진 것으로 간주
+                    print(f"[HEARTBEAT] Connection timeout ({elapsed:.1f}s since last activity)")
+                    raise websockets.ConnectionClosed(None, None)
+
+                # PING 메시지 전송
+                try:
+                    ping_message = json.dumps({"type": "PING"})
+                    await self._websocket.send(ping_message)
+                    print(f"[HEARTBEAT] PING sent (last activity: {elapsed:.1f}s ago)")
+                except websockets.ConnectionClosed:
+                    print("[HEARTBEAT] Connection closed during PING")
+                    break
+
+            except asyncio.CancelledError:
+                break
+            except websockets.ConnectionClosed:
+                break
+            except Exception as e:
+                print(f"[HEARTBEAT] Error in heartbeat loop: {e}")
+                await asyncio.sleep(1)
 
 
 async def get_approval_key():
@@ -265,7 +405,22 @@ async def run_publisher():
     # RPC 소비자 설정
     await setup_rpc_consumer(rabbitmq_channel, subscription_handler)
 
-    while reconnect_count < max_reconnect_attempts:
+    # 종료 시그널 핸들러 설정
+    def signal_handler():
+        print("[SHUTDOWN] Received shutdown signal")
+        shutdown_event.set()
+
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            loop.add_signal_handler(sig, signal_handler)
+        except NotImplementedError:
+            # Windows에서는 지원하지 않음
+            pass
+
+    heartbeat_manager = None
+
+    while reconnect_count < max_reconnect_attempts and not shutdown_event.is_set():
         try:
             print(f"Connecting to WebSocket: {uri} (attempt {reconnect_count + 1})")
             async with websockets.connect(uri) as ws:
@@ -283,7 +438,32 @@ async def run_publisher():
                 subscription_handler.set_websocket(ws, approval_key)
                 subscription_handler.set_test_mode(is_test_mode)
 
-                # 초기 구독 또는 재연결 시 복원
+                # HeartbeatManager 초기화
+                heartbeat_manager = HeartbeatManager(
+                    ws,
+                    ping_interval=PING_INTERVAL,
+                    ping_timeout=PING_TIMEOUT
+                )
+
+                # [KIS 가이드라인] 1단계: 접속 확인 대기
+                print("[WS] Waiting for connection confirmation...")
+                try:
+                    confirm_msg = await asyncio.wait_for(
+                        ws.recv(),
+                        timeout=CONNECTION_CONFIRM_TIMEOUT
+                    )
+                    if KISParser.is_connection_confirm(confirm_msg):
+                        print(f"[WS] Connection confirmed: {confirm_msg[:100]}...")
+                    else:
+                        print(f"[WS] First message received (treating as connected): {confirm_msg[:100]}...")
+                except asyncio.TimeoutError:
+                    # 테스트 모드에서는 확인 메시지 없이 진행
+                    if is_test_mode:
+                        print("[WS] No confirmation message (test mode), proceeding...")
+                    else:
+                        print("[WS] Connection confirmation timeout, proceeding anyway...")
+
+                # [KIS 가이드라인] 2단계: 구독 정보 등록
                 if subscription_handler.subscription_count > 0:
                     # 재연결: 기존 구독 복원
                     print("[WS] Restoring previous subscriptions...")
@@ -299,11 +479,27 @@ async def run_publisher():
                 reconnect_count = 0
                 reconnect_delay = 5
 
+                # [KIS 가이드라인] 3단계: PINGPONG 처리를 위한 하트비트 시작
+                await heartbeat_manager.start()
+
                 print(f"[WS] Listening for real-time data... "
                       f"(Active subscriptions: {subscription_handler.subscription_count})")
 
+                # [KIS 가이드라인] 4단계: 정보 수신
                 async for message in ws:
+                    # 종료 이벤트 체크
+                    if shutdown_event.is_set():
+                        print("[WS] Shutdown event detected")
+                        break
+
                     try:
+                        # 연결 활성 상태 기록
+                        heartbeat_manager.record_activity()
+
+                        # [KIS 가이드라인] PINGPONG 응답 처리
+                        if await heartbeat_manager.handle_pingpong(message):
+                            continue
+
                         # KIS API 형식 메시지 파싱 후 RabbitMQ에 발행
                         if message and len(message) > 0 and message[0] in ["0", "1"]:
                             parsed_data = KISParser.parse_trade_data(message)
@@ -327,13 +523,28 @@ async def run_publisher():
                         print(f"[ERROR] Error processing message: {e}")
                         continue
 
+                # [KIS 가이드라인] 5단계: 정상 종료 시 구독 해제
+                if shutdown_event.is_set():
+                    print("[WS] Graceful shutdown: unsubscribing all...")
+                    await heartbeat_manager.stop()
+                    await subscription_handler.unsubscribe_all()
+                    print("[WS] All subscriptions removed")
+                    break
+
         except websockets.ConnectionClosed as e:
+            if heartbeat_manager:
+                await heartbeat_manager.stop()
+
+            if shutdown_event.is_set():
+                break
+
             reconnect_count += 1
             print(
                 f"[RECONNECT] WebSocket connection closed: {e}. "
                 f"Attempt {reconnect_count}/{max_reconnect_attempts}. "
                 f"Reconnecting in {reconnect_delay}s..."
             )
+            # [KIS 가이드라인] 연결/종료 간격 최소 1초 이상 (현재 5초)
             await asyncio.sleep(reconnect_delay)
             reconnect_delay = min(reconnect_delay * 2, max_reconnect_delay)
 
@@ -341,6 +552,9 @@ async def run_publisher():
             print(f"[ERROR] Invalid WebSocket URI: {e}")
             raise
         except Exception as e:
+            if heartbeat_manager:
+                await heartbeat_manager.stop()
+
             # APP_KEY 중복 사용 에러 시 즉시 종료
             if "APP_KEY_IN_USE" in str(e):
                 print(
@@ -349,6 +563,9 @@ async def run_publisher():
                 await asyncio.sleep(60)
                 print("[FATAL] Exiting container to restart...")
                 raise SystemExit(1)
+
+            if shutdown_event.is_set():
+                break
 
             reconnect_count += 1
             print(f"[ERROR] Error in WebSocket loop: {e}")

--- a/kis-publisher/main.py
+++ b/kis-publisher/main.py
@@ -36,7 +36,6 @@ BATCH_SIZE = int(os.getenv("KIS_BATCH_SIZE", "5"))
 # PINGPONG 설정
 PING_INTERVAL = int(os.getenv("KIS_PING_INTERVAL", "30"))  # 30초마다 PING
 PING_TIMEOUT = int(os.getenv("KIS_PING_TIMEOUT", "10"))  # PONG 응답 타임아웃
-CONNECTION_CONFIRM_TIMEOUT = int(os.getenv("KIS_CONNECTION_CONFIRM_TIMEOUT", "10"))  # 연결 확인 타임아웃
 
 # 종료 플래그
 shutdown_event = asyncio.Event()
@@ -82,27 +81,6 @@ class KISParser:
             return False
         # KIS API PINGPONG 메시지 형식 확인
         return "PINGPONG" in message.upper() or message.strip().upper() == "PING"
-
-    @staticmethod
-    def is_connection_confirm(message: str) -> bool:
-        """연결 확인 메시지인지 확인"""
-        if not message:
-            return False
-        try:
-            # JSON 형식 응답 확인
-            data = json.loads(message)
-            # 연결 성공 응답 확인 (tr_id가 있거나 성공 메시지)
-            if isinstance(data, dict):
-                header = data.get("header", {})
-                body = data.get("body", {})
-                # 연결 확인 또는 구독 성공 응답
-                if header.get("tr_id") or body.get("rt_cd") == "0":
-                    return True
-        except (json.JSONDecodeError, TypeError):
-            pass
-        # 문자열 형식 확인
-        msg_upper = message.upper()
-        return "CONNECTED" in msg_upper or "SUCCESS" in msg_upper
 
 
 class HeartbeatManager:
@@ -445,25 +423,9 @@ async def run_publisher():
                     ping_timeout=PING_TIMEOUT
                 )
 
-                # [KIS 가이드라인] 1단계: 접속 확인 대기
-                print("[WS] Waiting for connection confirmation...")
-                try:
-                    confirm_msg = await asyncio.wait_for(
-                        ws.recv(),
-                        timeout=CONNECTION_CONFIRM_TIMEOUT
-                    )
-                    if KISParser.is_connection_confirm(confirm_msg):
-                        print(f"[WS] Connection confirmed: {confirm_msg[:100]}...")
-                    else:
-                        print(f"[WS] First message received (treating as connected): {confirm_msg[:100]}...")
-                except asyncio.TimeoutError:
-                    # 테스트 모드에서는 확인 메시지 없이 진행
-                    if is_test_mode:
-                        print("[WS] No confirmation message (test mode), proceeding...")
-                    else:
-                        print("[WS] Connection confirmation timeout, proceeding anyway...")
+                print("[WS] Connected, proceeding to subscription...")
 
-                # [KIS 가이드라인] 2단계: 구독 정보 등록
+                # [KIS 가이드라인] 1단계: 구독 정보 등록
                 if subscription_handler.subscription_count > 0:
                     # 재연결: 기존 구독 복원
                     print("[WS] Restoring previous subscriptions...")
@@ -479,13 +441,13 @@ async def run_publisher():
                 reconnect_count = 0
                 reconnect_delay = 5
 
-                # [KIS 가이드라인] 3단계: PINGPONG 처리를 위한 하트비트 시작
+                # [KIS 가이드라인] 2단계: PINGPONG 처리를 위한 하트비트 시작
                 await heartbeat_manager.start()
 
                 print(f"[WS] Listening for real-time data... "
                       f"(Active subscriptions: {subscription_handler.subscription_count})")
 
-                # [KIS 가이드라인] 4단계: 정보 수신
+                # [KIS 가이드라인] 3단계: 정보 수신
                 async for message in ws:
                     # 종료 이벤트 체크
                     if shutdown_event.is_set():

--- a/kis-publisher/subscription_handler.py
+++ b/kis-publisher/subscription_handler.py
@@ -231,3 +231,32 @@ class SubscriptionHandler:
     def clear_subscriptions(self):
         """구독 목록 초기화"""
         self._subscribed_codes.clear()
+
+    async def unsubscribe_all(self) -> dict:
+        """
+        모든 종목 구독 해제.
+
+        정상 종료 시 KIS 가이드라인에 따라 모든 구독을 해제합니다.
+
+        Returns:
+            {
+                "success": bool,
+                "unsubscribed": list[str],
+                "error": str
+            }
+        """
+        if not self._subscribed_codes:
+            print("[SubscriptionHandler] No active subscriptions to unsubscribe")
+            return {
+                "success": True,
+                "unsubscribed": [],
+                "error": None
+            }
+
+        codes_to_unsubscribe = list(self._subscribed_codes)
+        print(f"[SubscriptionHandler] Unsubscribing all {len(codes_to_unsubscribe)} codes...")
+
+        result = await self.unsubscribe(codes_to_unsubscribe)
+
+        print(f"[SubscriptionHandler] Unsubscribed: {len(result['unsubscribed'])} codes")
+        return result


### PR DESCRIPTION
## 🔎 개요

KIS 공식 가이드라인에서 요구하는 PINGPONG 메커니즘을 구현하고, 기업 삭제 로직을 수정했습니다.

## 📝 작업 내용

### 1. HeartbeatManager 클래스 추가 (`kis-publisher/main.py`)
- 비활성 타임아웃 감지 (기본 30초 간격, 10초 타임아웃)
- 연결 활성 상태 모니터링

### 2. PINGPONG 메시지 처리 (KIS 가이드라인 준수)
- 서버에서 PINGPONG 메시지 수신 시 **원본 메시지를 그대로 에코**
- `KISParser.is_pingpong_message()` 메서드로 PINGPONG 감지
- 클라이언트 PING 전송 로직 제거 (서버 주도 방식)

### 3. 불필요한 연결 확인 대기 로직 제거
- KIS 공식 예제와 동일하게 연결 후 바로 구독 처리
- 불필요한 타임아웃 지연 제거

### 4. asyncio 베스트 프랙티스 적용
- `shutdown_event`를 모듈 레벨에서 `run_publisher()` 내 per-loop 생성으로 변경
- import 시점의 Event 생성 문제 해결

### 5. 정상 종료 절차 구현
- `unsubscribe_all()` 메서드 추가 (`subscription_handler.py`)
- 종료 시그널(SIGINT, SIGTERM) 핸들링
- 구독 해제 후 연결 종료 순서 보장

### 6. 환경변수
| 환경변수 | 기본값 | 설명 |
|---------|--------|------|
| `KIS_PING_INTERVAL` | 30 | 비활성 체크 간격 (초) |
| `KIS_PING_TIMEOUT` | 10 | 비활성 타임아웃 (초) |

### 7. 기업 삭제 로직 수정 (`companies/services/company_cleanup.py`)
- **삭제 조건**: per, pbr, roe, debt_ratio, dividend_yield 5개 지표 중 **2개 이상**이 0 또는 null이면 삭제
- **유지 조건**: 5개 지표 중 4개 이상 유효한 값이 있으면 삭제하지 않음

## 👀 변경 사항

- `kis-publisher/main.py`: HeartbeatManager 클래스, PINGPONG 에코, 연결 확인 로직 제거, per-loop shutdown_event
- `kis-publisher/subscription_handler.py`: `unsubscribe_all()` 메서드 추가
- `companies/services/company_cleanup.py`: 삭제 조건 수정

## 📦 패키지 설치

없음

## #️⃣ 관련 이슈

Closes #91

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 웹소켓 연결에 대한 하트비트 관리 및 타임아웃 감지 기능 추가
  * 우아한 종료를 위한 신호 처리 추가
  * 구독 일괄 취소 기능 추가

* **버그 수정**
  * 회사 유효성 검사 기준 강화 (최소 4/5 메트릭 필요)
  * 연결 끊김 및 타임아웃 상황에서 안정성 개선

* **리팩토링**
  * 메시지 처리 및 라이프사이클 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->