### PR TITLE
[fix] PBR 계산 공식 수정 (총자본 → 순자산)

### DIFF
--- a/companies/models.py
+++ b/companies/models.py
@@ -105,7 +105,7 @@ class FinancialStatement(models.Model):
         null=True,
         blank=True,
         verbose_name="PBR (주가순자산비율)",
-        help_text="시가총액 ÷ 총자본",
+        help_text="시가총액 ÷ 순자산 (순자산 = 총자산 - 총부채)",
     )
     roe = models.DecimalField(
         max_digits=10,

--- a/companies/services/financial_metrics.py
+++ b/companies/services/financial_metrics.py
@@ -38,7 +38,7 @@ class FinancialMetricsService:
 
     @staticmethod
     def calculate_debt_ratio(
-        total_liabilities: int, total_equity: int
+        total_liabilities: Optional[int], total_equity: Optional[int]
     ) -> Optional[Decimal]:
         """
         부채비율 계산
@@ -50,7 +50,9 @@ class FinancialMetricsService:
         Returns:
             부채비율 (%), None if 계산 불가
         """
-        if not total_equity or total_equity <= 0:
+        if total_liabilities is None or total_equity is None:
+            return None
+        if total_equity <= 0:
             return None
 
         try:
@@ -82,7 +84,7 @@ class FinancialMetricsService:
 
     @staticmethod
     def calculate_pbr(
-        market_cap: int, total_assets: int, total_liabilities: int
+        market_cap: int, total_assets: Optional[int], total_liabilities: Optional[int]
     ) -> Optional[Decimal]:
         """
         PBR (주가순자산비율) 계산
@@ -95,7 +97,7 @@ class FinancialMetricsService:
         Returns:
             PBR (배), None if 계산 불가
         """
-        if not total_assets or not total_liabilities:
+        if total_assets is None or total_liabilities is None:
             return None
 
         try:
@@ -234,8 +236,8 @@ class FinancialMetricsService:
 
         # 2. 부채비율 계산 (재무제표 데이터만 사용)
         debt_ratio = self.calculate_debt_ratio(
-            financial_statement.total_liabilities or 0,
-            financial_statement.total_equity or 0,
+            financial_statement.total_liabilities,
+            financial_statement.total_equity,
         )
 
         # 3. PER 계산 (시가총액 + 재무제표)
@@ -246,8 +248,8 @@ class FinancialMetricsService:
         # 4. PBR 계산 (시가총액 + 순자산)
         pbr = self.calculate_pbr(
             company.market_amount,
-            financial_statement.total_assets or 0,
-            financial_statement.total_liabilities or 0,
+            financial_statement.total_assets,
+            financial_statement.total_liabilities,
         )
 
         # 5. 배당수익률 계산 (배당금 + 현재가)

--- a/companies/services/financial_metrics.py
+++ b/companies/services/financial_metrics.py
@@ -81,22 +81,30 @@ class FinancialMetricsService:
             return None
 
     @staticmethod
-    def calculate_pbr(market_cap: int, total_equity: int) -> Optional[Decimal]:
+    def calculate_pbr(
+        market_cap: int, total_assets: int, total_liabilities: int
+    ) -> Optional[Decimal]:
         """
         PBR (주가순자산비율) 계산
 
         Args:
             market_cap: 시가총액
-            total_equity: 총자본
+            total_assets: 총자산
+            total_liabilities: 총부채
 
         Returns:
             PBR (배), None if 계산 불가
         """
-        if not total_equity or total_equity <= 0:
+        if not total_assets or not total_liabilities:
             return None
 
         try:
-            pbr = Decimal(market_cap) / Decimal(total_equity)
+            # 순자산 = 총자산 - 총부채
+            net_assets = Decimal(total_assets) - Decimal(total_liabilities)
+            if net_assets <= 0:
+                return None
+
+            pbr = Decimal(market_cap) / net_assets
             return round(pbr, 2)
         except (InvalidOperation, ZeroDivisionError):
             return None
@@ -235,9 +243,11 @@ class FinancialMetricsService:
             company.market_amount, financial_statement.net_income or 0
         )
 
-        # 4. PBR 계산 (시가총액 + 재무제표)
+        # 4. PBR 계산 (시가총액 + 순자산)
         pbr = self.calculate_pbr(
-            company.market_amount, financial_statement.total_equity or 0
+            company.market_amount,
+            financial_statement.total_assets or 0,
+            financial_statement.total_liabilities or 0,
         )
 
         # 5. 배당수익률 계산 (배당금 + 현재가)


### PR DESCRIPTION
## 🔎 개요
PBR(주가순자산비율) 계산 공식을 올바르게 수정합니다.

## 📝 작업 내용
- 기존: `시가총액 / 총자본(total_equity)`
- 변경: `시가총액 / 순자산(총자산 - 총부채)`

### 수정된 파일
- `companies/services/financial_metrics.py` - `calculate_pbr()` 메서드
- `companies/models.py` - PBR 필드 help_text

## 👀 변경 사항
- 순자산이 0 이하인 경우 PBR은 None 반환
- 총자산 또는 총부채가 없는 경우 None 반환

## 📸 UI 스크린샷
해당 없음 (백엔드 로직 변경)

## 📦 패키지 설치
없음

## #️⃣ 관련 이슈
Closes #93

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * PBR(주가순자산비율) 분모를 총자산-총부채(순자산)으로 변경해 계산 정확도 개선 및 도움말 텍스트 업데이트.
  * 부채비율 및 기타 지표 계산에서 입력값이 없거나 유효하지 않을 경우 결과를 반환하지 않도록 처리하여 잘못된 출력 방지.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->